### PR TITLE
feat: add additional sample user logins

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,7 +13,10 @@ app.use(session({ secret: 'study-secret', resave: false, saveUninitialized: fals
 const users = [
   { email: 'admin@example.com', password: 'admin123', role: 'admin' },
   { email: 'alice@example.com', password: 'password123', role: 'user' },
-  { email: 'bob@example.com', password: 'password123', role: 'user' }
+  { email: 'bob@example.com', password: 'password123', role: 'user' },
+  { email: 'carol@example.com', password: 'password123', role: 'user' },
+  { email: 'dave@example.com', password: 'password123', role: 'user' },
+  { email: 'eve@example.com', password: 'password123', role: 'user' }
 ];
 
 function requireLogin(req, res, next) {

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -15,5 +15,14 @@
     <label>Password <input type="password" name="password" required></label><br>
     <button type="submit">Login</button>
   </form>
+  <h2>Sample Users</h2>
+  <ul>
+    <li>admin@example.com / admin123 (admin)</li>
+    <li>alice@example.com / password123</li>
+    <li>bob@example.com / password123</li>
+    <li>carol@example.com / password123</li>
+    <li>dave@example.com / password123</li>
+    <li>eve@example.com / password123</li>
+  </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand in-memory user store with three new sample accounts
- document all available demo credentials on the login page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaa102714c8327bf25d7ef13a87df8